### PR TITLE
Remove "-" after Surfshark Country

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -3,7 +3,7 @@ rm -rf ovpn_configs*
 wget -O ovpn_configs.zip https://api.surfshark.com/v1/server/configurations
 unzip ovpn_configs.zip -d ovpn_configs
 cd ovpn_configs
-VPN_FILE=$(ls | grep "${SURFSHARK_COUNTRY}-" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
+VPN_FILE=$(ls | grep "${SURFSHARK_COUNTRY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
 echo Choosed: ${VPN_FILE}
 printf "${SURFSHARK_USER}\n${SURFSHARK_PASSWORD}" > vpn-auth.txt
 openvpn --config $VPN_FILE --auth-user-pass vpn-auth.txt


### PR DESCRIPTION
The minus symbol is unnecessary and removes the ability to select single configs (e.g. de-fra-st001) because the name is de-fra-st001.prod.surfshark.com_tcp.ovpn