### PR TITLE
Allow access to attached container's web ui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV SURFSHARK_PASSWORD=
 ENV SURFSHARK_COUNTRY=
 ENV SURFSHARK_CITY=
 ENV CONNECTION_TYPE=tcp
+ENV LAN_NETWORK=
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s CMD curl -L 'https://ipinfo.io'
 COPY startup.sh .
 RUN apk add --update --no-cache openvpn wget unzip coreutils curl && chmod +x ./startup.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The link is established using the [OpenVPN](https://openvpn.net/) client.
 
 ## Configuration
 
-The container is configurable using 4 environment variables:
+The container is configurable using 5 environment variables:
 
 | Name | Mandatory | Description |
 |------|-----------|-------------|
@@ -28,6 +28,7 @@ The container is configurable using 4 environment variables:
 |SURFSHARK_COUNTRY|No|The country, supported by SurfShark, in which you want to connect|
 |SURFSHARK_CITY|No|The city of the country in which you want to connect|
 |CONNECTION_TYPE|No|The connection type that you want to use: tcp, udp|
+|LAN_NETWORK|No|Lan network used to access the web ui of attached containers. Comment out or leave blank: example 192.168.0.0/24|
 
 `SURFSHARK_USER` and `SURFSHARK_PASSWORD` are provided at the bottom of this page: [https://account.surfshark.com/setup/manual](https://account.surfshark.com/setup/manual).
 
@@ -52,6 +53,7 @@ services:
             - SURFSHARK_COUNTRY=it
             - SURFSHARK_CITY=mil
             - CONNECTION_TYPE=udp
+            - LAN_NETWORK=
         cap_add: 
             - NET_ADMIN
         devices:
@@ -80,5 +82,7 @@ If you want to attach a container to the VPN, you can simply run:
 ```sh
 sudo docker run -it --net=container:CONTAINER_NAME alpine /bin/sh
 ```
+
+If you want access to an attached container's web ui you will also need to expose those ports.  The attached container must not be started until this container is up and fully running.
 
 If you face network connection problems, I suggest you to set a specific DNS server for each container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
             - SURFSHARK_COUNTRY=it
             - SURFSHARK_CITY=mil
             - CONNECTION_TYPE=udp
+            - LAN_NETWORK=192.168.0.0/24      #Optional - Used to access attached containers web ui
+        ports:
+          - 1880:1880                         #Optional - Used to access attached containers web ui
         cap_add: 
             - NET_ADMIN
         devices:
@@ -25,3 +28,4 @@ services:
             - surfshark
         network_mode: service:surfshark
         restart: always
+

--- a/startup.sh
+++ b/startup.sh
@@ -4,6 +4,14 @@ wget -O ovpn_configs.zip https://api.surfshark.com/v1/server/configurations
 unzip ovpn_configs.zip -d ovpn_configs
 cd ovpn_configs
 VPN_FILE=$(ls | grep "${SURFSHARK_COUNTRY}" | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
-echo Choosed: ${VPN_FILE}
+echo Chose: ${VPN_FILE}
 printf "${SURFSHARK_USER}\n${SURFSHARK_PASSWORD}" > vpn-auth.txt
+
+if [ -n ${LAN_NETWORK}  ]
+then
+    DEFAULT_GATEWAY=$(ip -4 route list 0/0 | cut -d ' ' -f 3)
+    ip route add "${LAN_NETWORK}" via "${DEFAULT_GATEWAY}" dev eth0
+    echo Adding ip route add "${LAN_NETWORK}" via "${DEFAULT_GATEWAY}" dev eth0 for attached container's web ui access
+    echo Do not forget to expose the ports for attached container we ui access
+fi
 openvpn --config $VPN_FILE --auth-user-pass vpn-auth.txt

--- a/startup.sh
+++ b/startup.sh
@@ -11,7 +11,7 @@ if [ -n ${LAN_NETWORK}  ]
 then
     DEFAULT_GATEWAY=$(ip -4 route list 0/0 | cut -d ' ' -f 3)
     ip route add "${LAN_NETWORK}" via "${DEFAULT_GATEWAY}" dev eth0
-    echo Adding ip route add "${LAN_NETWORK}" via "${DEFAULT_GATEWAY}" dev eth0 for attached container's web ui access
+    echo Adding ip route add "${LAN_NETWORK}" via "${DEFAULT_GATEWAY}" dev eth0 for attached container web ui access
     echo Do not forget to expose the ports for attached container we ui access
 fi
 openvpn --config $VPN_FILE --auth-user-pass vpn-auth.txt


### PR DESCRIPTION
This allows attached containers witha Web UI access to those ports while using the VPN.
I added a new environment variable "LAN_NETWORK".  If the variable is empty no changes are made.  If it is not empty it will find the container Gateway and enter the command "ip route add <LAN_NETWORK> via <CONTAINER DEFAULT_GATEWAY> dev eth0".
I also updated "docker-compose.yml" and "README.md" to reflect the changes.