### PR TITLE
Fix wrong country being selected when city not provided.

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -3,7 +3,7 @@ rm -rf ovpn_configs*
 wget -O ovpn_configs.zip https://api.surfshark.com/v1/server/configurations
 unzip ovpn_configs.zip -d ovpn_configs
 cd ovpn_configs
-VPN_FILE=$(ls | grep "${SURFSHARK_COUNTRY}" | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
+VPN_FILE=$(ls "${SURFSHARK_COUNTRY}"* | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
 echo Chose: ${VPN_FILE}
 printf "${SURFSHARK_USER}\n${SURFSHARK_PASSWORD}" > vpn-auth.txt
 


### PR DESCRIPTION
When `SURFSHARK_CITY` is not provided (it's marked as optional in the documentation), a different country can be selected sometimes. For example, when trying to connect to Iceland (`SURFSHARK_COUNTRY=is`) a Turkish server can be selected, because the country pattern is matched for the city name (`ist`).

Or, another example of which servers will be considered when trying to connect to Ireland (`SURFSHARK_COUNTRY=ie`):
```
/vpn/ovpn_configs # ls | grep ie | grep "" | grep udp
at-vie.prod.surfshark.com_udp.ovpn
ie-dub.prod.surfshark.com_udp.ovpn
ua-iev.prod.surfshark.com_udp.ovpn
```