### PR TITLE
Switch to using the SurfShark API for the health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LAN_NETWORK=
 ENV CREATE_TUN_DEVICE=
 ENV OVPN_CONFIGS=
 ENV ENABLE_KILL_SWITCH=true
-HEALTHCHECK --interval=60s --timeout=10s --start-period=30s CMD curl -L 'https://ipinfo.io'
+HEALTHCHECK --interval=60s --timeout=10s --start-period=30s CMD curl -s https://api.surfshark.com/v1/server/user | grep '"secured":true'
 COPY startup.sh .
 COPY sockd.conf /etc/
 COPY sockd.sh .


### PR DESCRIPTION
The existing Healthcheck only verifies that the container has internet access, it doesn't verify that the connection is actually being routed via Surfshark.

This is problematic as during container bootup (ie. while `openvpn` is doing it's thing) the healthcheck will return truthful as  it has internet access, but not verify that it's connected via the VPN.

This is partially caused by the killswitch functionality being implemented after `openvpn` is connected, so before the VPN is connected any internet access is allowed.

This PR simply changes it to use an undocumented Surfshark API (It's used on https://surfshark.com/what-is-my-ip) to check that the internet access available is "secured" (aka surfshark)