### PR TITLE
Update to meet new openvpn config style

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -6,7 +6,7 @@ if [ -z "${OVPN_CONFIGS}" ]; then
 fi
 unzip "${OVPN_CONFIGS}" -d ovpn_configs
 cd ovpn_configs
-VPN_FILE=$(ls "${SURFSHARK_COUNTRY}"* | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
+VPN_FILE=$(ls rgb_"${SURFSHARK_COUNTRY}"* | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
 echo Chose: ${VPN_FILE}
 printf "${SURFSHARK_USER}\n${SURFSHARK_PASSWORD}" > vpn-auth.txt
 


### PR DESCRIPTION
Surfshark has changed their file structure, now configs are named like `rgb_au-bne.prod.surfshark.com_tcp.ovpn`.

Fixes #71.
Fixes #72.