### PR TITLE
Surfshark changed ovpn names again

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -6,7 +6,7 @@ if [ -z "${OVPN_CONFIGS}" ]; then
 fi
 unzip "${OVPN_CONFIGS}" -d ovpn_configs
 cd ovpn_configs
-VPN_FILE=$(ls *_"${SURFSHARK_COUNTRY}"* | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
+VPN_FILE=$(ls *"${SURFSHARK_COUNTRY}"-* | grep "${SURFSHARK_CITY}" | grep "${CONNECTION_TYPE}" | shuf | head -n 1)
 echo Chose: ${VPN_FILE}
 printf "${SURFSHARK_USER}\n${SURFSHARK_PASSWORD}" > vpn-auth.txt
 


### PR DESCRIPTION
from something like this:
`rgb_nl-ams.prod.surfshark.com_udp.ovpn`

to
`nl-ams.prod.surfshark.com_udp.ovpn`

I have added a - at the end of the country prefix. Do you think this would work? Or am I missing something?