### PR TITLE
Add option to not run the SOCKS server: `ENABLE_SOCKS_SERVER`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV CONNECTION_TYPE=tcp
 ENV LAN_NETWORK=
 ENV CREATE_TUN_DEVICE=
 ENV ENABLE_MASQUERADE=
-ENV ENABLE_SOCKS_SERVER=true
+ENV ENABLE_SOCKS_SERVER=
 ENV OVPN_CONFIGS=
 ENV ENABLE_KILL_SWITCH=true
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s CMD curl -s https://api.surfshark.com/v1/server/user | grep '"secured":true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV CONNECTION_TYPE=tcp
 ENV LAN_NETWORK=
 ENV CREATE_TUN_DEVICE=
 ENV ENABLE_MASQUERADE=
+ENV ENABLE_SOCKS_SERVER=true
 ENV OVPN_CONFIGS=
 ENV ENABLE_KILL_SWITCH=true
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s CMD curl -s https://api.surfshark.com/v1/server/user | grep '"secured":true'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The container is configurable using different environment variables:
 |LAN_NETWORK|No|Lan network used to access the web ui of attached containers. Can be comma seperated for multiple subnets Comment out or leave blank: example 192.168.0.0/24|
 |CREATE_TUN_DEVICE|No|Creates the TUN device, useful for NAS users|
 |ENABLE_MASQUERADE|No|Masquerade NAT allows you to translate multiple IP addresses to another single IP address.|
-|ss|No|Control whether the SOCKS server for the VPN is run or not(default: run)|
+|ENABLE_SOCKS_SERVER|No|Control whether the SOCKS server for the VPN is run or not(default: run)|
 |OVPN_CONFIGS|No|Manually provide the path used to read the "Surfshark_Config.zip" file (contains Surshark's OpenVPN configuration files)
 |ENABLE_KILL_SWITCH|No|Enable the kill-switch functionality
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The container is configurable using different environment variables:
 |LAN_NETWORK|No|Lan network used to access the web ui of attached containers. Can be comma seperated for multiple subnets Comment out or leave blank: example 192.168.0.0/24|
 |CREATE_TUN_DEVICE|No|Creates the TUN device, useful for NAS users|
 |ENABLE_MASQUERADE|No|Masquerade NAT allows you to translate multiple IP addresses to another single IP address.|
+|ss|No|Control whether the SOCKS server for the VPN is run or not(default: run)|
 |OVPN_CONFIGS|No|Manually provide the path used to read the "Surfshark_Config.zip" file (contains Surshark's OpenVPN configuration files)
 |ENABLE_KILL_SWITCH|No|Enable the kill-switch functionality
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The container is configurable using different environment variables:
 |LAN_NETWORK|No|Lan network used to access the web ui of attached containers. Can be comma seperated for multiple subnets Comment out or leave blank: example 192.168.0.0/24|
 |CREATE_TUN_DEVICE|No|Creates the TUN device, useful for NAS users|
 |ENABLE_MASQUERADE|No|Masquerade NAT allows you to translate multiple IP addresses to another single IP address.|
-|ENABLE_SOCKS_SERVER|No|Control whether the SOCKS server for the VPN is run or not(default: run)|
+|ENABLE_SOCKS_SERVER|No|Control whether the SOCKS server for the VPN is run or not(default: do not run)|
 |OVPN_CONFIGS|No|Manually provide the path used to read the "Surfshark_Config.zip" file (contains Surshark's OpenVPN configuration files)
 |ENABLE_KILL_SWITCH|No|Enable the kill-switch functionality
 

--- a/startup.sh
+++ b/startup.sh
@@ -38,7 +38,15 @@ if [ "${ENABLE_MASQUERADE}" = "true" ]; then
   iptables -t nat -A POSTROUTING -o tun+ -j MASQUERADE
 fi
 
-openvpn --config $VPN_FILE --auth-user-pass vpn-auth.txt --mute-replay-warnings $OPENVPN_OPTS --script-security 2 --up /vpn/sockd.sh
+
+OPTIONAL_SOCKS_SCRIPT=""
+# Enable NAT w MASQUERADE mode
+if [ "${ENABLE_SOCKS_SERVER}" = "true" ]; then
+  echo "Enable SOCKS Server for the VPN"
+  OPTIONAL_SOCKS_SCRIPT="--up /vpn/sockd.sh"
+fi
+
+openvpn --config $VPN_FILE --auth-user-pass vpn-auth.txt --mute-replay-warnings $OPENVPN_OPTS --script-security 2 ${OPTIONAL_SOCKS_SCRIPT}
 
 if [ "${ENABLE_KILL_SWITCH}" = "true" ]; then
   ufw reset


### PR DESCRIPTION
- I would like to not run the SOCKS server since I don't use it.
- So, this PR adds an option `ENABLE_SOCKS_SERVER` to control whether the SOCKS server is run or not.
- Please let me know there is any issue with the variable naming or the implementation.